### PR TITLE
Crossbuild with scala 2.11 and 2.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: scala
 scala:
-  - 2.11.6
+  - 2.11.12
+  - 2.12.8
 jdk:
   - oraclejdk8
 script:

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ name := "play-requestcount"
 
 version := "0.0.4"
 
-scalaVersion := "2.11.12"
+scalaVersion := "2.12.8"
 
 crossScalaVersions ++= Seq("2.11.12", "2.12.8")
 

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,9 @@ name := "play-requestcount"
 
 version := "0.0.4"
 
-scalaVersion := "2.11.6"
+scalaVersion := "2.11.12"
+
+crossScalaVersions ++= Seq("2.11.12", "2.12.8")
 
 scalacOptions ++= Seq("-deprecation")
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.11
+sbt.version=0.13.17

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,7 @@
 resolvers += Classpaths.sbtPluginReleases
 
 // Scoverage
-addSbtPlugin("org.scoverage" %% "sbt-scoverage" % "1.0.4")
+addSbtPlugin("org.scoverage" %% "sbt-scoverage" % "1.5.1")
 
 // Send Scoverage results to coveralls
 addSbtPlugin("org.scoverage" %% "sbt-coveralls" % "1.0.0")


### PR DESCRIPTION
Added cross build setting for upgrading Scala version used in Play 2.6 application to 2.12.

I upgraded the version of sbt-coverage because the old one is not available in Scala 2.12.
Also, since sbt-converage requires sbt 0.13.17 or higher, sbt has also been upgraded.